### PR TITLE
Torch filters

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -602,33 +602,6 @@ for p in ma_filter.torchparameters:
     print(f"{p} grad1={ma_filter.torchparameters[p].grad.item()} grad2={ma_filter2.torchparameters[p].grad.item()}")
 # -
 
-# Try to optimze the parameters of the second filter to match the first. **This isn't working**
-
-# +
-optimizer = torch.optim.Adam(list(ma_filter2.parameters()), lr=0.01)
-
-print(list(ma_filter.parameters()))
-print(list(ma_filter2.parameters()))
-
-for i in range(100):
-    optimizer.zero_grad()
-    
-    filtered1 = ma_filter(noise)
-    filtered2 = ma_filter2(noise)
-    
-    fft1 = torch.abs(torch.fft.fft(filtered1))
-    fft2 = torch.abs(torch.fft.fft(filtered2))
-    
-    err = torch.mean(torch.abs(fft1 - fft2))
-    
-    print(err)
-    err.backward()
-    optimizer.step()
-
-print(list(ma_filter.parameters()))
-print(list(ma_filter2.parameters()))
-# -
-
 # **FIR Lowpass**
 #
 # The TorchFIR filter implements a low-pass filter by approximating the impulse response of an ideal lowpass filter, which is a windowed sinc function in the time domain. We can set the exact cut-off frequency for this filter, all frequencies above this point are attenuated. The quality of the approximation is determined by the length of the filter, choosing a larger filter length will result in a filter with a steeper slope at the cutoff and more attenuation of high frequencies.

--- a/src/ddspdrum/module.py
+++ b/src/ddspdrum/module.py
@@ -987,7 +987,7 @@ class MovingAverage(SynthModule):
             ]
         )
 
-    def _npyforward(self, audio: np.ndarray) -> np.ndarray:
+    def _npyforward(self, audio_in: np.ndarray) -> np.ndarray:
         """
         Filter audio samples
 
@@ -996,7 +996,7 @@ class MovingAverage(SynthModule):
 
         audio (np.ndarray)  :   audio samples to filter
         """
-        length = self.p("length")
+        length = int(self.p("length"))
         impulse = np.ones(length) / length
-        y = np.convolve(audio, impulse)
+        y = np.convolve(audio_in, impulse)
         return y

--- a/src/ddspdrum/torchmodule.py
+++ b/src/ddspdrum/torchmodule.py
@@ -12,7 +12,8 @@ import torch.tensor as T
 
 from ddspdrum.defaults import BUFFER_SIZE, SAMPLE_RATE
 from ddspdrum.parameter import ParameterRange, TorchParameter
-from ddspdrum.torchutil import blackman, fix_length, midi_to_hz, normalize, sinc
+from ddspdrum.torchutil import (blackman, fix_length, midi_to_hz, normalize,
+                                sinc)
 
 torch.pi = torch.acos(torch.zeros(1)).item() * 2  # which is 3.1415927410125732
 

--- a/src/ddspdrum/torchmodule.py
+++ b/src/ddspdrum/torchmodule.py
@@ -539,7 +539,11 @@ class TorchFIR(TorchSynthModule):
         impulse = self.windowed_sinc(self.p("cutoff"), self.p("length"))
         impulse = torch.reshape(impulse, (1, 1, impulse.size()[0]))
         audio_resized = torch.reshape(audio_in, (1, 1, audio_in.size()[0]))
-        y = nn.functional.conv1d(audio_resized, impulse, padding=int(self.p("length") / 2))
+        y = nn.functional.conv1d(
+            audio_resized,
+            impulse,
+            padding=int(self.p("length") / 2)
+        )
         return y[0][0]
 
     def windowed_sinc(self, cutoff: T, filter_length: T) -> T:
@@ -626,5 +630,9 @@ class TorchMovingAverage(TorchSynthModule):
             impulse = torch.cat((impulse, additional), dim=2)
 
         audio_resized = torch.reshape(audio_in, (1, 1, audio_in.size()[0]))
-        y = nn.functional.conv1d(audio_resized, impulse, padding=int(impulse.size()[0] / 2))
+        y = nn.functional.conv1d(
+            audio_resized,
+            impulse,
+            padding=int(impulse.size()[0] / 2)
+        )
         return y[0][0]

--- a/src/ddspdrum/torchmodule.py
+++ b/src/ddspdrum/torchmodule.py
@@ -538,8 +538,8 @@ class FIRLowPass(TorchSynthModule):
         """
 
         impulse = self.windowed_sinc(self.p("cutoff"), self.p("length"))
-        impulse = torch.reshape(impulse, (1, 1, impulse.size()[0]))
-        audio_resized = torch.reshape(audio_in, (1, 1, audio_in.size()[0]))
+        impulse = impulse.view(1, 1, impulse.size()[0])
+        audio_resized = audio_in.view(1, 1, audio_in.size()[0])
         y = nn.functional.conv1d(
             audio_resized,
             impulse,
@@ -613,7 +613,7 @@ class TorchMovingAverage(TorchSynthModule):
             additional = torch.ones(1, 1, 1) * (1.0 - torch.sum(impulse))
             impulse = torch.cat((impulse, additional), dim=2)
 
-        audio_resized = torch.reshape(audio_in, (1, 1, audio_in.size()[0]))
+        audio_resized = audio_in.view(1, 1, audio_in.size()[0])
         y = nn.functional.conv1d(
             audio_resized,
             impulse,

--- a/src/ddspdrum/torchutil.py
+++ b/src/ddspdrum/torchutil.py
@@ -7,9 +7,10 @@ and rename this to util.py.
 TODO: These should operate on vectors, many of these assume scalar Tensors.
 """
 
+import math
+
 import torch
 import torch.tensor as T
-import math
 
 from ddspdrum.defaults import EPSILON, EQ_POW
 
@@ -115,9 +116,9 @@ def blackman(length: T) -> T:
 
     # Linearly interpolate the ends of the window to achieve fractional length
     window = torch.cat((
-        T([0.0 * diff + window[1] * (1.0 - diff)], device=length.device),
+        T([0.0 * diff + window[0] * (1.0 - diff)], device=length.device),
         window[1:-1],
-        T([0.0 * diff + window[-2] * (1.0 - diff)], device=length.device)
+        T([0.0 * diff + window[-1] * (1.0 - diff)], device=length.device)
     ))
 
     return window

--- a/tests/test_torchmodule.py
+++ b/tests/test_torchmodule.py
@@ -109,7 +109,7 @@ class TestTorchSynthModule:
     def test_TorchFmVCO(self):
         # Is this correct?
         numpymod = numpymodule.FmVCO()
-        torchmod = torchmodule.TorchSineVCO()
+        torchmod = torchmodule.TorchFmVCO()
         self._compare_values(
             numpymod,
             torchmod,
@@ -117,18 +117,6 @@ class TestTorchSynthModule:
                 "mod_signal": _random_signal
             }
         )
-
-    # Fuzzy test doesn't work for filtering
-    # def test_TorchMovingAverage(self):
-    #     numpymod = numpymodule.MovingAverage()
-    #     torchmod = torchmodule.TorchMovingAverage()
-    #     self._compare_values(
-    #         numpymod,
-    #         torchmod,
-    #         param_name_to_randfn={
-    #             "audio_in": _random_signal
-    #         }
-    #     )
 
     def test_get_parameter(self):
         module = torchmodule.TorchSynthModule()

--- a/tests/test_torchmodule.py
+++ b/tests/test_torchmodule.py
@@ -67,7 +67,7 @@ class TestTorchSynthModule:
                 ny = str(type(e))
                 threw = True
             for name in params:
-                params[name] = T(params[name])
+                params[name] = T(params[name]).float()
             try:
                 ty = torchmod(**params).detach().numpy()
             except Exception as e:
@@ -107,6 +107,7 @@ class TestTorchSynthModule:
         )
 
     def test_TorchFmVCO(self):
+        # Is this correct?
         numpymod = numpymodule.FmVCO()
         torchmod = torchmodule.TorchSineVCO()
         self._compare_values(
@@ -116,6 +117,18 @@ class TestTorchSynthModule:
                 "mod_signal": _random_signal
             }
         )
+
+    # Fuzzy test doesn't work for filtering
+    # def test_TorchMovingAverage(self):
+    #     numpymod = numpymodule.MovingAverage()
+    #     torchmod = torchmodule.TorchMovingAverage()
+    #     self._compare_values(
+    #         numpymod,
+    #         torchmod,
+    #         param_name_to_randfn={
+    #             "audio_in": _random_signal
+    #         }
+    #     )
 
     def test_get_parameter(self):
         module = torchmodule.TorchSynthModule()

--- a/tests/test_torchutil.py
+++ b/tests/test_torchutil.py
@@ -140,3 +140,15 @@ class TestTorchUtil:
                 "signal": "signal"
             }
         )
+
+    def test_sinc(self):
+        x = np.linspace(-4, 4, 41)
+        numpy_sinc = np.sinc(x / np.pi)
+        torch_sinc = torchutil.sinc(T(x).float())
+        assert np.allclose(numpy_sinc, torch_sinc.numpy())
+
+    def test_blackman(self):
+        length = 128
+        torch_blackman = torch.blackman_window(length, False)
+        blackman_2 = torchutil.blackman(T(length).float())
+        assert np.allclose(blackman_2.numpy(), torch_blackman.numpy(), atol=1e-07)


### PR DESCRIPTION
Starting to make some differentiable filters. Moving average and FIR LPF are included in this PR. In the future I think we are going to want to compute convolutions in the frequency domain as opposed to doing it using torch conv1d as that will likely be more efficient, this is what Engel et al. did in the DDSP work. But I will leave that for a future change since this is working for now. Not including fuzzy tests since the numpy convolution operation and torch.nn.functional.conv1d operations aren't quite the same.