### PR TITLE
Add simple signal class

### DIFF
--- a/tests/test_torchutil.py
+++ b/tests/test_torchutil.py
@@ -7,7 +7,7 @@ import torch
 import torch.tensor as T
 
 import torchsynth.util as util
-
+import torchsynth.signal as Signal
 
 class TestTorchUtil:
     """
@@ -34,9 +34,10 @@ class TestTorchUtil:
 
     def test_fix_length2D(self):
         signal1 = torch.rand([2, 88100])
+        signal1 = Signal(signal1)
         assert util.fix_length2D(signal1, length=T(44100)).shape == (2, 44100)
         assert util.fix_length2D(signal1, length=T(90000)).shape == (2, 90000)
-        signal2 = T([[1, 2, 3], [4, 5, 6]])
+        signal2 = Signal(T([[1, 2, 3], [4, 5, 6]]))
         assert torch.all(
             util.fix_length2D(signal2, length=T(4)) == T([[1, 2, 3, 0], [4, 5, 6, 0]])
         )

--- a/tests/test_torchutil.py
+++ b/tests/test_torchutil.py
@@ -7,7 +7,7 @@ import torch
 import torch.tensor as T
 
 import torchsynth.util as util
-import torchsynth.signal as Signal
+from torchsynth.signal import Signal
 
 class TestTorchUtil:
     """
@@ -37,7 +37,7 @@ class TestTorchUtil:
         signal1 = Signal(signal1)
         assert util.fix_length2D(signal1, length=T(44100)).shape == (2, 44100)
         assert util.fix_length2D(signal1, length=T(90000)).shape == (2, 90000)
-        signal2 = Signal(T([[1, 2, 3], [4, 5, 6]]))
+        signal2 = Signal(T([[1, 2, 3], [4, 5, 6]]).float())
         assert torch.all(
             util.fix_length2D(signal2, length=T(4)) == T([[1, 2, 3, 0], [4, 5, 6, 0]])
         )

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -12,6 +12,7 @@ import torch.tensor as T
 import torchsynth.util as util
 from torchsynth.defaults import BUFFER_SIZE, SAMPLE_RATE
 from torchsynth.parameter import ModuleParameter, ModuleParameterRange
+from torchsynth.signal import Signal
 
 torch.pi = torch.acos(torch.zeros(1)).item() * 2  # which is 3.1415927410125732
 

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -131,7 +131,7 @@ class TorchSynthModule1D(TorchSynthModule):
     # TODO: have these already moved to cuda
     def __init__(
         self,
-        batch_size: T,
+        batch_size: int,
         sample_rate: T = T(SAMPLE_RATE),
         buffer_size: T = T(BUFFER_SIZE),
     ):
@@ -159,7 +159,7 @@ class TorchSynthModule1D(TorchSynthModule):
         # assert seconds.ndim == 1
         return torch.round(seconds * self.sample_rate).int()
 
-    def _forward(self, *args: Any, **kwargs: Any) -> T:  # pragma: no cover
+    def _forward(self, *args: Any, **kwargs: Any) -> Signal:  # pragma: no cover
         """
         Each TorchSynthModule should override this.
         """

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -353,7 +353,7 @@ class TorchADSR(TorchSynthModule1D):
         # Apply scaling factor.
         ramp = torch.pow(ramp, self.p("alpha")[:, None])
 
-        return ramp
+        return Signal(ramp)
 
     def make_attack(self) -> Signal:
         return self._ramp(torch.zeros(self.batch_size), self.p("attack"))

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -1,18 +1,13 @@
 """
 A convenience type for signals.
+I'd like to call this filename signal.py but it conflicts with
+a core python module.
 """
 
 import torch
 
 
 class Signal(torch.Tensor):
-    @staticmethod
-    def __new__(cls, x, *args, **kwargs):
-        return super().__new__(cls, x, *args, **kwargs)
-
-    def __init__(self, x):
-        super().__init__(x)  # optional
-
     @property
     def batch_size(self):
         assert self.ndim == 2

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -1,0 +1,16 @@
+"""
+A convenience type for signals.
+"""
+
+import torch.tensor as T
+
+class Signal(T):
+    @property
+    def batch_size(self):
+        assert self.ndim == 2
+        return self.shape[0]
+
+    @property
+    def nsamples(self):
+        assert self.ndim == 2
+        return self.shape[1]

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -4,13 +4,14 @@ A convenience type for signals.
 
 import torch
 
+
 class Signal(torch.Tensor):
     @staticmethod
     def __new__(cls, x, *args, **kwargs):
         return super().__new__(cls, x, *args, **kwargs)
 
     def __init__(self, x):
-        super().__init__(x) # optional
+        super().__init__(x)  # optional
 
     @property
     def batch_size(self):

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -14,6 +14,6 @@ class Signal(torch.Tensor):
         return self.shape[0]
 
     @property
-    def nsamples(self):
+    def num_samples(self):
         assert self.ndim == 2
         return self.shape[1]

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -2,10 +2,16 @@
 A convenience type for signals.
 """
 
-import torch.tensor as T
+import torch
 
+class Signal(torch.Tensor):
+    @staticmethod
+    def __new__(cls, x, *args, **kwargs):
+        return super().__new__(cls, x, *args, **kwargs)
 
-class Signal(T):
+    def __init__(self, x):
+        super().__init__(x) # optional
+
     @property
     def batch_size(self):
         assert self.ndim == 2

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -4,6 +4,7 @@ A convenience type for signals.
 
 import torch.tensor as T
 
+
 class Signal(T):
     @property
     def batch_size(self):

--- a/torchsynth/util.py
+++ b/torchsynth/util.py
@@ -10,6 +10,7 @@ import torch
 import torch.tensor as T
 
 from torchsynth.defaults import EPSILON, EQ_POW
+from torchsynth.signal import Signal
 
 
 # What is amin here? And maybe we should convert it to a value in defaults?
@@ -67,21 +68,17 @@ def fix_length(signal: T, length: int) -> T:
     return signal
 
 
-def fix_length2D(signal: T, length: T) -> T:
+def fix_length2D(signal: Signal, length: T) -> T:
     """
     Pad or truncate array to specified length.
     """
-
     assert length.ndim == 0
     assert signal.ndim == 2
-    if signal.shape[1] < length:
-        signal = torch.nn.functional.pad(signal, (0, length - signal.shape[1]))
-    elif signal.shape[1] > length:
+    if signal.nsamples < length:
+        signal = torch.nn.functional.pad(signal, (0, length - signal.nsamples))
+    elif signal.nsamples > length:
         signal = signal[:, :length]
-    assert signal.shape == (
-        signal.shape[0],
-        length,
-    )
+    assert signal.shape == (signal.batch_size, length)
     return signal
 
 

--- a/torchsynth/util.py
+++ b/torchsynth/util.py
@@ -68,7 +68,7 @@ def fix_length(signal: T, length: int) -> T:
     return signal
 
 
-def fix_length2D(signal: Signal, length: T) -> T:
+def fix_length2D(signal: Signal, length: T) -> Signal:
     """
     Pad or truncate array to specified length.
     """

--- a/torchsynth/util.py
+++ b/torchsynth/util.py
@@ -74,9 +74,9 @@ def fix_length2D(signal: Signal, length: T) -> Signal:
     """
     assert length.ndim == 0
     assert signal.ndim == 2
-    if signal.nsamples < length:
-        signal = torch.nn.functional.pad(signal, (0, length - signal.nsamples))
-    elif signal.nsamples > length:
+    if signal.num_samples < length:
+        signal = torch.nn.functional.pad(signal, (0, length - signal.num_samples))
+    elif signal.num_samples > length:
         signal = signal[:, :length]
     assert signal.shape == (signal.batch_size, length)
     return signal


### PR DESCRIPTION
We now have a simple Signal class for 2D signals, with convenience methods batch_size and num_samples.

If we start typing everything with Signal as we port, and use the batch_size and num_samples convenience properties, we will avoid bugs like squeezing things to the wrong ndim