### PR TITLE
Integration test

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
     - name: python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+        pip install -e ".[test]"
         pip install pytest
     - name: Test with pytest
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,3 +29,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Run integration test
+      run: |
+        python examples/examples.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
     - name: python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e ".[dev]"
         pip install pytest
     - name: Test with pytest
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,15 @@ matrix:
     - os: linux
       dist: groovy
       python: 3.9
-    - os: osx
-      # Would be nice to try different python versions :(
-      #python: 3.7
-      osx_image: xcode10.2
-    - os: osx
-      # Would be nice to try different python versions :(
-      #python: 3.7
-      osx_image: xcode12.4
+    # https://travis-ci.community/t/how-to-skip-python-download-to-osx-image-and-avoid-download-unavailable-error/9554/2
+    #- os: osx
+    #  # Would be nice to try different python versions :(
+    #  #python: 3.7
+    #  osx_image: xcode10.2
+    #- os: osx
+    #  # Would be nice to try different python versions :(
+    #  #python: 3.7
+    #  osx_image: xcode12.4
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,24 @@ matrix:
     - os: linux
       dist: bionic
       python: 3.9
+    - os: linux
+      dist: xenial
+      python: 3.7
+    - os: linux
+      dist: xenial
+      python: 3.8
+    - os: linux
+      dist: xenial
+      python: 3.9
+    - os: linux
+      dist: groovy
+      python: 3.7
+    - os: linux
+      dist: groovy
+      python: 3.8
+    - os: linux
+      dist: groovy
+      python: 3.9
     - os: osx
       # Would be nice to try different python versions :(
       #python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,8 @@ before_install:
   - pip install -U pytest
 install:
   - pip install ".[dev]" . # install package + test dependencies
-jobs:
-  include:
-    - stage: Unit test
-      script: pytest
-    - stage: Integration test
-      script: python examples/examples.py
+script:
+  - pytest
+  - python examples/examples.py
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,6 @@ matrix:
       dist: bionic
       python: 3.9
     - os: linux
-      dist: xenial
-      python: 3.7
-    - os: linux
-      dist: xenial
-      python: 3.8
-    - os: linux
-      dist: xenial
-      python: 3.9
-    - os: linux
       dist: groovy
       python: 3.7
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
             - g++-10
             - uuid-dev
             - clang-10
+            - llvm-10
     - os: osx
       compiler: clang
       osx_image: xcode10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - pip install -U pip
   - pip install -U pytest
 install:
-  - pip install ".[test]" . # install package + test dependencies
+  - pip install ".[dev]" . # install package + test dependencies
 jobs:
   include:
     - stage: Unit test

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - pip install -U pip
   - pip install -U pytest
 install:
-  - pip install ".[dev]" . # install package + test dependencies
+  - pip install ".[test]" . # install package + test dependencies
 script:
   - pytest
   - python examples/examples.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
             - llvm-10
     - os: osx
       compiler: clang
+      python: 3.9
       osx_image: xcode10.2
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,65 @@ python:
   - 3.7
   - 3.8
   - 3.9
+
+matrix:
+  include:
+    - os: linux
+      dist: focal
+      compiler: clang
+      python: 3.7
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
+          packages:
+            - g++-10
+            - uuid-dev
+            - clang-10
+    - os: linux
+      dist: focal
+      compiler: clang
+      python: 3.8
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
+          packages:
+            - g++-10
+            - uuid-dev
+            - clang-10
+    - os: linux
+      dist: focal
+      compiler: clang
+      python: 3.9
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
+          packages:
+            - g++-10
+            - uuid-dev
+            - clang-10
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+    - os: linux
+      dist: xenial
+      compiler: clang
+      python: 3.7
+    - os: linux
+      dist: xenial
+      compiler: clang
+      python: 3.8
+    - os: linux
+      dist: xenial
+      compiler: clang
+      python: 3.9
+    - os: osx
+      osx_image: xcode10.2
+#    - os: linux
+#      dist: trusty
+
 before_install:
   - python --version
   - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ before_install:
   - pip install -U pytest
 install:
   - pip install ".[test]" . # install package + test dependencies
-script: pytest
+jobs:
+  include:
+    - stage: Unit test
+      script: pytest
+    - stage: Integration test
+      script: python examples/examples.py
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,11 @@
 language:
   python
-python:
-  - 3.7
-  - 3.8
-  - 3.9
 
 matrix:
   include:
     - os: linux
       dist: focal
       compiler: clang
-      python: 3.7
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
-          packages:
-            - g++-10
-            - uuid-dev
-            - clang-10
-    - os: linux
-      dist: focal
-      compiler: clang
-      python: 3.8
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
-          packages:
-            - g++-10
-            - uuid-dev
-            - clang-10
-    - os: linux
-      dist: focal
-      compiler: clang
       python: 3.9
       addons:
         apt:
@@ -46,22 +18,6 @@ matrix:
     - os: osx
       compiler: clang
       osx_image: xcode10.2
-    - os: linux
-      dist: xenial
-      compiler: clang
-      python: 3.7
-    - os: linux
-      dist: xenial
-      compiler: clang
-      python: 3.8
-    - os: linux
-      dist: xenial
-      compiler: clang
-      python: 3.9
-    - os: osx
-      osx_image: xcode10.2
-#    - os: linux
-#      dist: trusty
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,8 @@ matrix:
       dist: bionic
       python: 3.9
     - os: osx
-      python: 3.7
-      osx_image: xcode10.2
-    - os: osx
-      python: 3.8
-      osx_image: xcode10.2
-    - os: osx
-      python: 3.9
+      # Would be nice to try different python versions :(
+      #python: 3.7
       osx_image: xcode10.2
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ matrix:
       # Would be nice to try different python versions :(
       #python: 3.7
       osx_image: xcode10.2
+    - os: osx
+      # Would be nice to try different python versions :(
+      #python: 3.7
+      osx_image: xcode12.4
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,29 @@ matrix:
   include:
     - os: linux
       dist: focal
-      compiler: clang
+      python: 3.7
+    - os: linux
+      dist: focal
+      python: 3.8
+    - os: linux
+      dist: focal
       python: 3.9
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
-          packages:
-            - g++-10
-            - uuid-dev
-            - clang-10
-            - llvm-10
+    - os: linux
+      dist: bionic
+      python: 3.7
+    - os: linux
+      dist: bionic
+      python: 3.8
+    - os: linux
+      dist: bionic
+      python: 3.9
     - os: osx
-      compiler: clang
+      python: 3.7
+      osx_image: xcode10.2
+    - os: osx
+      python: 3.8
+      osx_image: xcode10.2
+    - os: osx
       python: 3.9
       osx_image: xcode10.2
 

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -8,7 +8,7 @@
 # %matplotlib inline
 
 # +
-def isnotebook():
+def isnotebook(): # pragma: no cover
     try:
         shell = get_ipython().__class__.__name__
         if shell == 'ZMQInteractiveShell':
@@ -25,7 +25,7 @@ def isnotebook():
 print(f"isnotebook = {isnotebook()}")
 
 # +
-if isnotebook():
+if isnotebook(): # pragma: no cover
     import IPython.display as ipd
     from IPython.core.display import display
     import librosa
@@ -56,7 +56,7 @@ else:
 
 
 def time_plot(signal, sample_rate=SAMPLE_RATE, show=True):
-    if isnotebook():
+    if isnotebook(): # pragma: no cover
         t = np.linspace(0, len(signal) / sample_rate, len(signal), endpoint=False)
         plt.plot(t, signal)
         plt.xlabel("Time")
@@ -66,7 +66,7 @@ def time_plot(signal, sample_rate=SAMPLE_RATE, show=True):
 
 
 def stft_plot(signal, sample_rate=SAMPLE_RATE):
-    if isnotebook():
+    if isnotebook(): # pragma: no cover
         X = librosa.stft(signal)
         Xdb = librosa.amplitude_to_db(abs(X))
         plt.figure(figsize=(5, 5))
@@ -344,7 +344,7 @@ for i in range(100):
     err.backward()
     optimizer.step()
 
-if isnotebook():
+if isnotebook(): # pragma: no cover
     plt.plot(error_hist)
     plt.ylabel("Error")
     plt.xlabel("Optimization steps")

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,10 @@ setup(
     python_requires=">=3.6",
     install_requires=["numpy", "scipy", "torch>=1.7"],
     extras_require={
+        "test": [
+            "pytest",
+            "pytest-cov",
+        ],
         "dev": [
             "pytest",
             "pytest-cov",


### PR DESCRIPTION
Add integration tests explicitly, i.e. examples.py must run start to end.

This was checked before by code coverage, but now is done as an explicit step.

examples.py now uses is_notebook(). When you're in Jupyter you get pretty plots and stuff. When you run from console as an integration test, that stuff is skipped