### PR TITLE
Facilitate various note_on_dur

### DIFF
--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -10,7 +10,6 @@ import torch.tensor as T
 
 import torchsynth.util as util
 from torchsynth.defaults import DEFAULT_BUFFER_SIZE, DEFAULT_SAMPLE_RATE, EPSILON
-
 from torchsynth.parameter import ModuleParameter, ModuleParameterRange
 from torchsynth.signal import Signal
 

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -10,6 +10,7 @@ import torch.tensor as T
 
 import torchsynth.util as util
 from torchsynth.defaults import DEFAULT_BUFFER_SIZE, DEFAULT_SAMPLE_RATE, EPSILON
+
 from torchsynth.parameter import ModuleParameter, ModuleParameterRange
 from torchsynth.signal import Signal
 

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -313,9 +313,9 @@ class TorchADSR(TorchSynthModule):
         ramp = torch.minimum(ramp, T(1.0))
 
         """
-        The following is a workaround. In inverse mode, a ramp with 0 duration 
-        (that is all 1's) becomes all 0's, which is a problem for the 
-        ultimate calculation of the ADSR signal (a * d * r => 0's). So this 
+        The following is a workaround. In inverse mode, a ramp with 0 duration
+        (that is all 1's) becomes all 0's, which is a problem for the
+        ultimate calculation of the ADSR signal (a * d * r => 0's). So this
         replaces only rows who sum to 0 (i.e., all components are zero).
         """
 


### PR DESCRIPTION
It's a little hairy but the adsr's will now work with various note_on_dur sizes. Needs to be refactored once note_on_dur is a parameter.

Also, "attack" behaviour isn't perfect, as it always goes up to 1 rather than some fractional value if `hold_on_dur` is less than the attack amount. That's ok though, this is a kind of self-normalization.