### PR TITLE
Hyperparams idea

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -599,6 +599,19 @@ if isnotebook():
     axes[1].set_title("Logarithmic Scaling")
 # -
 
+# ### Hyperparameters
+#
+# ParameterRanges are considered hyperparameters in torchsynth and can be viewed and modified through a Synth
+
+voice1.hyperparameters
+
+from torchsynth.module import SynthModule
+
+for n, m in voice1.named_modules():
+    if isinstance(m, SynthModule):
+        print(n)
+        print(m.parameters())
+
 # ### Filters
 
 # +

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -603,16 +603,12 @@ if isnotebook():
 #
 # ParameterRanges are considered hyperparameters in torchsynth and can be viewed and modified through a Synth
 
+# View all hyperparameters
 voice1.hyperparameters
 
-voice1.set_hyperparameter(("keyboard", "midi_f0", "curve"), 0.0)
-
-from torchsynth.module import SynthModule
-
-for n, m in voice1.named_modules():
-    if isinstance(m, SynthModule):
-        print(n)
-        print(m.parameters())
+# Set a specific hyperparameter
+voice1.set_hyperparameter(("keyboard", "midi_f0", "curve"), 0.1)
+print(voice1.hyperparameters[("keyboard", "midi_f0", "curve")])
 
 # ### Filters
 

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -605,6 +605,8 @@ if isnotebook():
 
 voice1.hyperparameters
 
+voice1.set_hyperparameter(("keyboard", "midi_f0", "curve"), 0.0)
+
 from torchsynth.module import SynthModule
 
 for n, m in voice1.named_modules():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 __author__ = "Joseph Turian, Jordie Shier, Max Henry"
 __contact__ = ""
 __url__ = ""

--- a/torchsynth/synth.py
+++ b/torchsynth/synth.py
@@ -85,7 +85,7 @@ class AbstractSynth(LightningModule):
         self, include_frozen: Optional[bool] = False
     ) -> Dict[Tuple[str, str], ModuleParameter]:
         """
-        Property that returns a dictionary of ModuleParameters for this synth keyed
+        Returns a dictionary of ModuleParameters for this synth keyed
         on a tuple of the SynthModule name and the parameter name
         """
         parameters = []

--- a/torchsynth/synth.py
+++ b/torchsynth/synth.py
@@ -81,8 +81,7 @@ class AbstractSynth(LightningModule):
 
             self.add_module(name, module)
 
-    @property
-    def synth_parameters(
+    def get_parameters(
         self, include_frozen: Optional[bool] = False
     ) -> Dict[Tuple[str, str], ModuleParameter]:
         """
@@ -183,7 +182,7 @@ class AbstractSynth(LightningModule):
         on a tuple of the module name, parameter name, and hyperparameter name
         """
         hparams = []
-        for param_key, parameter in self.synth_parameters.items():
+        for param_key, parameter in self.get_parameters().items():
             hparams.append(((*param_key, "curve"), parameter.parameter_range.curve))
             hparams.append(
                 ((*param_key, "symmetric"), parameter.parameter_range.symmetric)
@@ -197,9 +196,9 @@ class AbstractSynth(LightningModule):
         hyperparameter to set, and the value to set it to.
         """
         module = getattr(self, hyperparameter[0])
-        parameter = getattr(module, hyperparameter[1])
+        parameter = module.get_parameter(hyperparameter[1])
         assert not ModuleParameter.is_parameter_frozen(parameter)
-        setattr(parameter, hyperparameter[2], value)
+        setattr(parameter.parameter_range, hyperparameter[2], value)
 
     def randomize(self, seed: Optional[int] = None):
         """

--- a/torchsynth/synth.py
+++ b/torchsynth/synth.py
@@ -82,7 +82,7 @@ class AbstractSynth(LightningModule):
             self.add_module(name, module)
 
     def get_parameters(
-        self, include_frozen: Optional[bool] = False
+        self, include_frozen: bool = False
     ) -> Dict[Tuple[str, str], ModuleParameter]:
         """
         Returns a dictionary of ModuleParameters for this synth keyed
@@ -182,10 +182,18 @@ class AbstractSynth(LightningModule):
         on a tuple of the module name, parameter name, and hyperparameter name
         """
         hparams = []
-        for param_key, parameter in self.get_parameters().items():
-            hparams.append(((*param_key, "curve"), parameter.parameter_range.curve))
+        for (module_name, parameter_name), parameter in self.get_parameters().items():
             hparams.append(
-                ((*param_key, "symmetric"), parameter.parameter_range.symmetric)
+                (
+                    (module_name, parameter_name, "curve"),
+                    parameter.parameter_range.curve,
+                )
+            )
+            hparams.append(
+                (
+                    (module_name, parameter_name, "symmetric"),
+                    parameter.parameter_range.symmetric,
+                )
             )
 
         return dict(hparams)


### PR DESCRIPTION
Cleaner way to get all the ModuleParameters for a synth keyed on the unique combination of module name and parameter name. Use this to set hyperparams.   