### PR TITLE
SynthConfig as non-Tensors

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -46,7 +46,7 @@ jobs:
         verbose: true
     - name: Generate coverage report with tests
       run: |
-        pytest --cov-report=xml --cov=./torchsynth tests/
+        TORCHSYNTH_DEBUG=True pytest --cov-report=xml --cov=./torchsynth tests/
     - name: Upload pytest coverage to Codecov
       uses: codecov/codecov-action@v1.2.0
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
         pip install pytest
     - name: Test with pytest
       run: |
-        pytest
+        TORCHSYNTH_DEBUG=True pytest
     - name: Run integration test
       run: |
         python examples/examples.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
 install:
   - pip install ".[test]" . # install package + test dependencies
 script:
-  - pytest
+  - TORCHSYNTH_DEBUG=True pytest
   - python examples/examples.py
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,3 @@ in terms of throughput.
 [![Travis CI build status](https://travis-ci.com/turian/torchsynth.png)](https://travis-ci.com/turian/torchsynth)
 
 [Homepage](https://torchsynth.rtfd.io/en/latest/).
-
-
-## Development Installation

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Unit testing is performed using `pytest`.
 
 To run tests, run `pytest` from the project root:
 ```
-pytest
+TORCHSYNTH_DEBUG=True pytest
 ```
 
 To run tests with a coverage report:

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -64,7 +64,6 @@ import torch.tensor as tensor
 from torch import Tensor as T
 
 from torchsynth.config import SynthConfig
-from torchsynth.default import DEFAULT_BUFFER_SIZE, DEFAULT_SAMPLE_RATE
 from torchsynth.module import (
     ADSR,
     VCA,
@@ -91,7 +90,7 @@ else:
     device = "cpu"
 
 
-def time_plot(signal, sample_rate=DEFAULT_SAMPLE_RATE, show=True):
+def time_plot(signal, sample_rate=44100, show=True):
     if isnotebook():  # pragma: no cover
         t = np.linspace(0, len(signal) / sample_rate, len(signal), endpoint=False)
         plt.plot(t, signal)
@@ -101,7 +100,7 @@ def time_plot(signal, sample_rate=DEFAULT_SAMPLE_RATE, show=True):
             plt.show()
 
 
-def stft_plot(signal, sample_rate=DEFAULT_SAMPLE_RATE):
+def stft_plot(signal, sample_rate=44100):
     if isnotebook():  # pragma: no cover
         X = librosa.stft(signal)
         Xdb = librosa.amplitude_to_db(abs(X))

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -63,8 +63,8 @@ import torch.fft
 import torch.tensor as tensor
 from torch import Tensor as T
 
-from torchsynth.default import DEFAULT_BUFFER_SIZE, DEFAULT_SAMPLE_RATE
 from torchsynth.config import SynthConfig
+from torchsynth.default import DEFAULT_BUFFER_SIZE, DEFAULT_SAMPLE_RATE
 from torchsynth.module import (
     ADSR,
     VCA,
@@ -112,18 +112,14 @@ def stft_plot(signal, sample_rate=DEFAULT_SAMPLE_RATE):
 
 # ## Globals
 # We'll generate 2 sounds at once, 4 seconds each
-synthconfig = SynthConfig(
-    batch_size=2, sample_rate=44100, buffer_size_seconds=4.0
-)
+synthconfig = SynthConfig(batch_size=2, sample_rate=44100, buffer_size_seconds=4.0)
 
 # For a few examples, we'll only generate one sound
-synthconfig1 = SynthConfig(
-    batch_size=1, sample_rate=44100, buffer_size_seconds=4.0
-)
+synthconfig1 = SynthConfig(batch_size=1, sample_rate=44100, buffer_size_seconds=4.0)
 
 # And a short one sound
 synthconfig1short = SynthConfig(
-    batch_size=1, sample_rate=44100, buffer_size_seconds = 0.1
+    batch_size=1, sample_rate=44100, buffer_size_seconds=0.1
 )
 
 # ## The Envelope
@@ -539,9 +535,7 @@ print(err)
 #
 # Let's generate some random synths in batch
 
-synthconfig16 = SynthConfig(
-    batch_size=16, sample_rate=44100, buffer_size_seconds=4
-)
+synthconfig16 = SynthConfig(batch_size=16, sample_rate=44100, buffer_size_seconds=4)
 voice = Voice(synthconfig=synthconfig16).to(device)
 voice_out = voice()
 for i in range(synthconfig16.batch_size):

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -113,17 +113,17 @@ def stft_plot(signal, sample_rate=DEFAULT_SAMPLE_RATE):
 # ## Globals
 # We'll generate 2 sounds at once, 4 seconds each
 synthconfig = SynthConfig(
-    batch_size=tensor(2), sample_rate=tensor(44100), buffer_size=tensor(4 * 44100)
+    batch_size=2, sample_rate=44100, buffer_size_seconds=4.0
 )
 
 # For a few examples, we'll only generate one sound
 synthconfig1 = SynthConfig(
-    batch_size=tensor(1), sample_rate=tensor(44100), buffer_size=tensor(4 * 44100)
+    batch_size=1, sample_rate=44100, buffer_size_seconds=4.0
 )
 
 # And a short one sound
 synthconfig1short = SynthConfig(
-    batch_size=tensor(1), sample_rate=tensor(44100), buffer_size=tensor(4096)
+    batch_size=1, sample_rate=44100, buffer_size_seconds = 0.1
 )
 
 # ## The Envelope
@@ -540,7 +540,7 @@ print(err)
 # Let's generate some random synths in batch
 
 synthconfig16 = SynthConfig(
-    batch_size=tensor(16), sample_rate=tensor(44100), buffer_size=tensor(4 * 44100)
+    batch_size=16, sample_rate=44100, buffer_size_seconds=4
 )
 voice = Voice(synthconfig=synthconfig16).to(device)
 voice_out = voice()

--- a/examples/lightningsynth.py
+++ b/examples/lightningsynth.py
@@ -86,7 +86,7 @@ synth1B = batch_idx_dataset(1024 * 1024 * 1024 // BATCH_SIZE)
 
 test_dataloader = torch.utils.data.DataLoader(synth1B, num_workers=0, batch_size=1)
 
-synthconfig = SynthConfig(batch_size=tensor(BATCH_SIZE))
+synthconfig = SynthConfig(batch_size=BATCH_SIZE)
 voice = Voice(synthconfig)
 
 accelerator = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,11 @@ from torch import Tensor as T
 from torchsynth.config import SynthConfig
 
 
-def test_synth_globals():
+def test_synth_config_debug():
+    synthconfig = SynthConfig(64)
+    assert synthconfig.debug
+
+def test_synth_config():
     synthconfig = SynthConfig(64)
     assert synthconfig.batch_size == 64
 

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -7,37 +7,22 @@ import pytest
 import torch.tensor as tensor
 from torch import Tensor as T
 
-from torchsynth.default import (
-    DEFAULT_BUFFER_SIZE,
-    DEFAULT_CONTROL_RATE,
-    DEFAULT_SAMPLE_RATE,
-)
 from torchsynth.config import SynthConfig
 
 
 def test_synth_globals():
-    synthconfig = SynthConfig(tensor(64))
-    assert synthconfig.sample_rate == DEFAULT_SAMPLE_RATE
+    synthconfig = SynthConfig(64)
     assert synthconfig.batch_size == 64
-    assert synthconfig.buffer_size == DEFAULT_BUFFER_SIZE
-    assert synthconfig.control_rate == DEFAULT_CONTROL_RATE
-    assert (
-        synthconfig.control_buffer_size
-        == DEFAULT_BUFFER_SIZE / DEFAULT_SAMPLE_RATE * synthconfig.control_rate
-    )
 
     # Test passing in specific values
     synthconfig = SynthConfig(
-        tensor(65),
-        sample_rate=tensor(16000),
-        buffer_size=tensor(8000),
-        control_rate=tensor(1000),
+        batch_size=65,
+        sample_rate=16000,
+        buffer_size_seconds=0.5,
+        control_rate=1000,
     )
     assert synthconfig.control_rate == 1000
     assert synthconfig.sample_rate == 16000
+    assert synthconfig.buffer_size_seconds == 0.5
     assert synthconfig.buffer_size == 8000
     assert synthconfig.control_buffer_size == 500
-
-    # Control rate must be passed in as a tensor
-    with pytest.raises(AttributeError):
-        SynthConfig(tensor(16), control_rate=1000)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -5,12 +5,10 @@ Tests for torch synth modules.
 import pytest
 import torch
 import torch.tensor as tensor
-from torch import Tensor as T
 
 import torchsynth
 import torchsynth.module as synthmodule
 from torchsynth.config import SynthConfig
-from torchsynth.parameter import ModuleParameter, ModuleParameterRange
 
 
 class TestSynthModule:
@@ -77,7 +75,7 @@ class TestSynthModule:
     """
 
     def test_set_parameter(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         module = synthmodule.ADSR(synthconfig, attack=tensor([0.5, 1.0]))
 
         # Confirm value set correctly from constructor
@@ -94,14 +92,14 @@ class TestSynthModule:
 
     def test_seconds_to_sample(self):
         synthconfig = torchsynth.config.SynthConfig(
-            batch_size=tensor(2), sample_rate=tensor(48000)
+            batch_size=2, sample_rate=48000
         )
         module = synthmodule.SineVCO(synthconfig)
         samples = module.seconds_to_samples(4.0)
         assert samples == 4 * 48000
 
     def test_softmodeselector(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         mode_selector = synthmodule.SoftModeSelector(
             synthconfig, device=self.device, n_modes=3
         )
@@ -120,7 +118,7 @@ class TestSynthModule:
         )
 
     def test_hardmodeselector(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         mode_selector = synthmodule.HardModeSelector(
             synthconfig, device=self.device, n_modes=3
         )
@@ -136,7 +134,7 @@ class TestSynthModule:
         )
 
     def test_audiomixer(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
 
         # Make sure parameters get setup correctly
         mixer = synthmodule.AudioMixer(synthconfig, device=self.device, n_input=3)
@@ -160,7 +158,7 @@ class TestSynthModule:
             )
 
     def test_modulationmixer(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
 
         mixer = synthmodule.ModulationMixer(
             synthconfig, device=self.device, n_input=2, n_output=2
@@ -194,9 +192,9 @@ class TestSynthModule:
         # of noise signals. All these noise samples should equal each other.
         # i.e., noise should be returned deterministically regardless of the
         # batch size.
-        synthconfig32 = SynthConfig(tensor(32))
-        synthconfig64 = SynthConfig(tensor(64))
-        synthconfig128 = SynthConfig(tensor(128))
+        synthconfig32 = SynthConfig(32)
+        synthconfig64 = SynthConfig(64)
+        synthconfig128 = SynthConfig(128)
 
         noise32 = synthmodule.Noise(synthconfig32, seed=0)
         noise64 = synthmodule.Noise(synthconfig64, seed=0)
@@ -216,13 +214,13 @@ class TestSynthModule:
         with pytest.raises(ValueError):
             # If the batch size if larger than the default
             # of 64, then this should complain
-            synthconfig65 = SynthConfig(tensor(65))
+            synthconfig65 = SynthConfig(65)
             synthmodule.Noise(synthconfig65, seed=0)
 
 
 class TestControlRateModule:
     def test_properties(self):
-        synthconfig = torchsynth.config.SynthConfig(tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(2)
         adsr = synthmodule.ADSR(synthconfig)
 
         # Sample rate and buffer size should raise errors
@@ -232,7 +230,6 @@ class TestControlRateModule:
         with pytest.raises(NotImplementedError):
             adsr.buffer_size
 
-        assert adsr.control_rate == torchsynth.default.DEFAULT_CONTROL_RATE
         expected_buffer = synthconfig.buffer_size / synthconfig.sample_rate
         expected_buffer *= adsr.control_rate
         assert adsr.control_buffer_size == expected_buffer

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -91,9 +91,7 @@ class TestSynthModule:
             assert parameter.device.type == self.device
 
     def test_seconds_to_sample(self):
-        synthconfig = torchsynth.config.SynthConfig(
-            batch_size=2, sample_rate=48000
-        )
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2, sample_rate=48000)
         module = synthmodule.SineVCO(synthconfig)
         samples = module.seconds_to_samples(4.0)
         assert samples == 4 * 48000

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -3,12 +3,14 @@ Tests for the profile script - hard to capture the output, but this also serves
 as an integration test to make sure the PyTorch Lightning training stuff is working.
 """
 
+import csv
 import os
 import sys
-import csv
-from torchsynth import profile
 import unittest.mock
+
 import pytest
+
+from torchsynth import profile
 
 
 class TestProfile:

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -25,15 +25,15 @@ class TestAbstractSynth:
     def test_construction(self):
         # Test empty construction
         synthconfig = torchsynth.config.SynthConfig(
-            sample_rate=tensor(16000), buffer_size=tensor(512), batch_size=tensor(2)
+            sample_rate=16000, buffer_size_seconds=0.3, batch_size=2
         )
         # Test construction with args
         synth = torchsynth.synth.AbstractSynth(synthconfig)
-        assert synth.sample_rate == tensor(16000)
-        assert synth.buffer_size == tensor(512)
+        assert synth.sample_rate == 16000
+        assert synth.buffer_size_seconds == 0.3
 
     def test_add_synth_module(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         synth = torchsynth.synth.AbstractSynth(synthconfig).to(self.device)
         synth.add_synth_modules(
             [
@@ -85,7 +85,7 @@ class TestAbstractSynth:
     def test_deterministic_noise(self):
         # This test confirms that randomizing a synth with the same
         # seed results in the same audio results.
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         cpusynth = torchsynth.synth.Voice(synthconfig)
 
         cpusynth.randomize(1)
@@ -132,7 +132,7 @@ class TestAbstractSynth:
             assert torch.mean(torch.abs(cuda2.detach().cpu() - x2)) < 3e-3
 
     def test_randomize_parameter_freezing(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         synth = torchsynth.synth.Voice(synthconfig)
 
         midi_val = tensor([69.0, 40.0])
@@ -202,7 +202,7 @@ class TestAbstractSynth:
             synth.randomize(1)
 
     def test_freeze_parameters(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         synth = torchsynth.synth.Voice(synthconfig)
 
         for param in synth.parameters():
@@ -231,7 +231,7 @@ class TestAbstractSynth:
                 assert not param.frozen
 
     def test_set_frozen_parameters(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         synth = torchsynth.synth.Voice(synthconfig)
 
         synth.set_frozen_parameters(
@@ -258,7 +258,7 @@ class TestAbstractSynth:
         assert torch.all(synth.adsr_1.p("attack").eq(tensor([1.5, 1.5])))
 
     def test_get_parameters(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         synth = torchsynth.synth.Voice(synthconfig)
         params = synth.get_parameters()
         assert len(params) > 0
@@ -278,7 +278,7 @@ class TestAbstractSynth:
         assert ("keyboard", "midi_f0") in synth.get_parameters()
 
     def test_set_hyperparameters(self):
-        synthconfig = torchsynth.config.SynthConfig(batch_size=tensor(2))
+        synthconfig = torchsynth.config.SynthConfig(batch_size=2)
         synth = torchsynth.synth.Voice(synthconfig)
         hparams = synth.hyperparameters
         for (module_name, param_name, subname), value in hparams.items():

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
 import torch
-import torch.tensor as tensor
-from torch import Tensor as T
+
 
 class SynthConfig:
     """
@@ -18,7 +17,7 @@ class SynthConfig:
         sample_rate: Optional[int] = 44100,
         buffer_size_seconds: Optional[float] = 4.0,
         control_rate: Optional[int] = 441,
-        debug: bool = False
+        debug: bool = False,
     ):
         """
         Args:
@@ -39,7 +38,9 @@ class SynthConfig:
         # Buffer size for control signals -- this is calculated to have the
         # same duration in seconds as that buffer size for the audio rate
         # signals. Rounded to the nearest integer number of samples.
-        self.control_buffer_size = torch.tensor(int(torch.round((self.buffer_size / sample_rate * control_rate))))
+        self.control_buffer_size = torch.tensor(
+            int(torch.round((self.buffer_size / sample_rate * control_rate)))
+        )
 
     def to(self, device: torch.device):
         # Only helpful to have sample and control rates on device, and as a float

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -3,6 +3,7 @@ from typing import Optional
 import torch
 import os
 
+
 class SynthConfig:
     """
     Any SynthModule and AbstractSynth might use

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -40,8 +40,11 @@ class SynthConfig:
         # Buffer size for control signals -- this is calculated to have the
         # same duration in seconds as that buffer size for the audio rate
         # signals. Rounded to the nearest integer number of samples.
-        self.control_buffer_size = torch.tensor(
-            int(torch.round((self.buffer_size / sample_rate * control_rate)))
+        self.control_buffer_size = (
+            torch.round((self.buffer_size / sample_rate * control_rate))
+            .clone()
+            .detach()
+            .int()
         )
 
     def to(self, device: torch.device):

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -27,6 +27,7 @@ class SynthConfig:
         sample_rate: Optional[T] = tensor(DEFAULT_SAMPLE_RATE),
         buffer_size: Optional[T] = tensor(DEFAULT_BUFFER_SIZE),
         control_rate: Optional[T] = tensor(DEFAULT_CONTROL_RATE),
+        debug: bool = False
     ):
         """
         Args:
@@ -35,6 +36,7 @@ class SynthConfig:
             sample_rate (T) : Scalar sample rate for audio generation.
             buffer_size (T) : Duration of the output, 4 seconds by default.
             control_rate (T) : Scalar sample rate for control signal generation.
+            debug (bool) : Run slow assertion tests. (Default: False)
         """
         assert batch_size.ndim == 0
         assert sample_rate.ndim == 0

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -4,13 +4,6 @@ import torch
 import torch.tensor as tensor
 from torch import Tensor as T
 
-from torchsynth.default import (
-    DEFAULT_BUFFER_SIZE,
-    DEFAULT_CONTROL_RATE,
-    DEFAULT_SAMPLE_RATE,
-)
-
-
 class SynthConfig:
     """
     Any SynthModule and AbstractSynth might use
@@ -24,9 +17,9 @@ class SynthConfig:
     def __init__(
         self,
         batch_size: T,
-        sample_rate: Optional[T] = tensor(DEFAULT_SAMPLE_RATE),
-        buffer_size: Optional[T] = tensor(DEFAULT_BUFFER_SIZE),
-        control_rate: Optional[T] = tensor(DEFAULT_CONTROL_RATE),
+        sample_rate: Optional[T] = tensor(44100),
+        buffer_size_seconds: Optional[T] = tensor(4),
+        control_rate: Optional[T] = tensor(441),
         debug: bool = False
     ):
         """
@@ -40,11 +33,11 @@ class SynthConfig:
         """
         assert batch_size.ndim == 0
         assert sample_rate.ndim == 0
-        assert buffer_size.ndim == 0
+        assert buffer_size_seconds.ndim == 0
         assert control_rate.ndim == 0
         self.batch_size = batch_size
         self.sample_rate = sample_rate
-        self.buffer_size = buffer_size
+        self.buffer_size = int(round(buffer_size_seconds * self.sample_rate))
         self.control_rate = control_rate
 
         # Buffer size for control signals -- this is calculated to have the

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import torch
-
+import os
 
 class SynthConfig:
     """
@@ -17,7 +17,7 @@ class SynthConfig:
         sample_rate: Optional[int] = 44100,
         buffer_size_seconds: Optional[float] = 4.0,
         control_rate: Optional[int] = 441,
-        debug: bool = False,
+        debug: bool = "TORCHSYNTH_DEBUG" in os.environ,
     ):
         """
         Args:
@@ -26,7 +26,8 @@ class SynthConfig:
             sample_rate (int) : Scalar sample rate for audio generation.
             buffer_size (float) : Duration of the output in seconds [default: 4.0]
             control_rate (int) : Scalar sample rate for control signal generation.
-            debug (bool) : Run slow assertion tests. (Default: False)
+            debug (bool) : Run slow assertion tests. (Default: False, unless
+                    environment variable TORCHSYNTH_DEBUG exists.)
         """
         self.batch_size = torch.tensor(batch_size)
         self.sample_rate = torch.tensor(sample_rate)

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -10,45 +10,36 @@ class SynthConfig:
     these global configuration values.
     Every SynthModule in the same AbstractSynth
     should have the save SynthConfig.
-
-    # TODO batch size and buffer size should not be tensors
     """
 
     def __init__(
         self,
-        batch_size: T,
-        sample_rate: Optional[T] = tensor(44100),
-        buffer_size_seconds: Optional[T] = tensor(4),
-        control_rate: Optional[T] = tensor(441),
+        batch_size: int,
+        sample_rate: Optional[int] = 44100,
+        buffer_size_seconds: Optional[float] = 4.0,
+        control_rate: Optional[int] = 441,
         debug: bool = False
     ):
         """
         Args:
-            batch_size (T)  : Scalar that indicates how many parameter settings
+            batch_size (int)  : Scalar that indicates how many parameter settings
             there are, i.e. how many different sounds to generate.
-            sample_rate (T) : Scalar sample rate for audio generation.
-            buffer_size (T) : Duration of the output, 4 seconds by default.
-            control_rate (T) : Scalar sample rate for control signal generation.
+            sample_rate (int) : Scalar sample rate for audio generation.
+            buffer_size (float) : Duration of the output in seconds [default: 4.0]
+            control_rate (int) : Scalar sample rate for control signal generation.
             debug (bool) : Run slow assertion tests. (Default: False)
         """
-        assert batch_size.ndim == 0
-        assert sample_rate.ndim == 0
-        assert buffer_size_seconds.ndim == 0
-        assert control_rate.ndim == 0
-        self.batch_size = batch_size
-        self.sample_rate = sample_rate
-        self.buffer_size = int(round(buffer_size_seconds * self.sample_rate))
-        self.control_rate = control_rate
+        self.batch_size = torch.tensor(batch_size)
+        self.sample_rate = torch.tensor(sample_rate)
+        self.buffer_size_seconds = torch.tensor(buffer_size_seconds)
+        self.buffer_size = torch.tensor(int(round(buffer_size_seconds * sample_rate)))
+        self.control_rate = torch.tensor(control_rate)
+        self.debug = debug
 
         # Buffer size for control signals -- this is calculated to have the
         # same duration in seconds as that buffer size for the audio rate
         # signals. Rounded to the nearest integer number of samples.
-        self.control_buffer_size = (
-            torch.round((buffer_size / sample_rate * control_rate))
-            .clone()
-            .detach()
-            .int()
-        )
+        self.control_buffer_size = torch.tensor(int(torch.round((self.buffer_size / sample_rate * control_rate))))
 
     def to(self, device: torch.device):
         # Only helpful to have sample and control rates on device, and as a float

--- a/torchsynth/default.py
+++ b/torchsynth/default.py
@@ -1,14 +1,6 @@
 """
 Default parameters
 """
-DEFAULT_SAMPLE_RATE = 48000
-
-# Modulation signals are computer at a lower sample rate
-DEFAULT_CONTROL_RATE = 480
-
-# Number of samples for fixed length synthesis.
-# 4 seconds by default
-DEFAULT_BUFFER_SIZE = 4 * DEFAULT_SAMPLE_RATE
 
 # Default batch size for rendering sounds.
 DEFAULT_BATCH_SIZE = 64

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -13,9 +13,9 @@ from torch import Tensor as T
 
 import torchsynth.util as util
 from torchsynth.config import SynthConfig
+from torchsynth.default import DEFAULT_BATCH_SIZE, EPS
 from torchsynth.parameter import ModuleParameter, ModuleParameterRange
 from torchsynth.signal import Signal
-from torchsynth.default import DEFAULT_BATCH_SIZE, EPS
 
 
 class SynthModule(nn.Module):

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -12,11 +12,10 @@ import torch.tensor as tensor
 from torch import Tensor as T
 
 import torchsynth.util as util
-from torchsynth.oldconfig import DEBUG
-from torchsynth.default import DEFAULT_BATCH_SIZE, EPS
 from torchsynth.config import SynthConfig
 from torchsynth.parameter import ModuleParameter, ModuleParameterRange
 from torchsynth.signal import Signal
+from torchsynth.default import DEFAULT_BATCH_SIZE, EPS
 
 
 class SynthModule(nn.Module):
@@ -332,7 +331,7 @@ class ADSR(ControlRateModule):
         behind the scenes to make the playing experience feel natural.
         """
 
-        if DEBUG:
+        if self.synthconfig.debug:
             assert note_on_duration.ndim == 1
             assert torch.all(note_on_duration > 0.0)
 
@@ -485,7 +484,7 @@ class VCO(SynthModule):
 
         control_as_frequency = self.make_control_as_frequency(midi_f0, mod_signal)
 
-        if DEBUG:
+        if self.synthconfig.debug:
             assert (control_as_frequency >= 0).all() and (
                 control_as_frequency <= self.nyquist
             ).all()

--- a/torchsynth/oldconfig.py
+++ b/torchsynth/oldconfig.py
@@ -1,5 +1,0 @@
-"""
-torchsynth configuration
-"""
-
-DEBUG = True

--- a/torchsynth/profile.py
+++ b/torchsynth/profile.py
@@ -15,23 +15,24 @@ Args:
     device: Set to run on cuda or cpu. Defaults to None, selects cuda if available
 """
 
-import sys
 import argparse
-from typing import Any
 import cProfile
-import pstats
 import io
+import multiprocessing
+import pstats
+import sys
+from typing import Any
 
+import pytorch_lightning as pl
 import torch
 import torch.tensor as T
-import pytorch_lightning as pl
-import multiprocessing
+
+import torchsynth.synth  # noqa: E402
+from torchsynth.config import SynthConfig  # noqa: E402
+from torchsynth.synth import AbstractSynth  # noqa: E402
 
 # TODO: Disable DEBUG
 
-import torchsynth.synth  # noqa: E402
-from torchsynth.synth import AbstractSynth  # noqa: E402
-from torchsynth.config import SynthConfig  # noqa: E402
 
 # Check for available GPUs and processing cores
 GPUS = torch.cuda.device_count()
@@ -62,9 +63,7 @@ class TorchSynthCallback(pl.Callback):
         _ = pl_module(batch_idx)
 
 
-def instantiate_module(
-    name: str, synthconfig: SynthConfig, **kwargs
-) -> AbstractSynth:
+def instantiate_module(name: str, synthconfig: SynthConfig, **kwargs) -> AbstractSynth:
     """
     Try to instantiate the module corresponding to the name providing
     """

--- a/torchsynth/profile.py
+++ b/torchsynth/profile.py
@@ -27,11 +27,7 @@ import torch.tensor as T
 import pytorch_lightning as pl
 import multiprocessing
 
-# Turn off torchsynth debug mode before importing anything else
-# TODO: https://github.com/turian/torchsynth/issues/259
-import torchsynth.oldconfig
-
-torchsynth.oldconfig.DEBUG = False
+# TODO: Disable DEBUG
 
 import torchsynth.synth  # noqa: E402
 from torchsynth.synth import AbstractSynth  # noqa: E402

--- a/torchsynth/profile.py
+++ b/torchsynth/profile.py
@@ -29,7 +29,7 @@ import torch.tensor as T
 
 import torchsynth.synth  # noqa: E402
 from torchsynth.config import SynthConfig  # noqa: E402
-from torchsynth.synth import AbstractSynth  # noqa: E402
+from torchsynth.synth import AbstractSynth
 
 # TODO: Disable DEBUG
 

--- a/torchsynth/synth.py
+++ b/torchsynth/synth.py
@@ -57,6 +57,11 @@ class AbstractSynth(LightningModule):
         assert self.synthconfig.buffer_size.ndim == 0
         return self.synthconfig.buffer_size
 
+    @property
+    def buffer_size_seconds(self) -> T:
+        assert self.synthconfig.buffer_size_seconds.ndim == 0
+        return self.synthconfig.buffer_size_seconds
+
     def add_synth_modules(
         self, modules: List[Tuple[str, SynthModule, Optional[Dict[str, Any]]]]
     ):


### PR DESCRIPTION
https://github.com/turian/torchsynth/pull/267https://github.com/turian/torchsynth/pull/267 should be merged first for a smaller diff

I am trying to simplify the synth configuration, and it will be a sequence of linear PRs. Here is one that turns most of the configs back into Python native values.

@jorshi can you profile quickly to make sure this is okay before we merge?